### PR TITLE
fix link order

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,7 @@ jobs:
       - name: fmt
         run: |
           make fmt
+          git diff --exit-code
       - name: test
         run: |
           make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 FetchContent_Declare(
   vsag
   GIT_REPOSITORY https://github.com/alipay/vsag
-  GIT_TAG v0.11.6
+  GIT_TAG v0.11.7
 )
 FetchContent_MakeAvailable(vsag)
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .PHONY: fmt
 fmt:
 	find src include -iname "*.h" -o -iname "*.cpp" | xargs clang-format -i
+	cargo fmt
 
 .PHONY: test
 test:

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=include/wrapper.h");
     println!("cargo:rerun-if-changed=src/wrapper.cpp");
+    println!("cargo:rerun-if-changed=build.rs");
 
     let dst = cmake::Config::new("")
         .build_target("vsag_wrapper")
@@ -23,11 +24,11 @@ fn main() {
         .env("TARGET", "")
         .build();
 
+    println!("cargo:rustc-link-lib=static=vsag_wrapper");
+    println!("cargo:rustc-link-lib=dylib=vsag");
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!(
         "cargo:rustc-link-search=native={}/build/_deps/vsag-build/src",
         dst.display()
     );
-    println!("cargo:rustc-link-lib=dylib=vsag");
-    println!("cargo:rustc-link-lib=static=vsag_wrapper");
 }

--- a/include/wrapper.h
+++ b/include/wrapper.h
@@ -18,7 +18,9 @@
 #include <cstddef>
 #include <cstdint>
 
+#ifdef __cplusplus
 extern "C" {
+#endif
 
 #define VSAG_WRAPPER_MAX_ERROR_MESSAGE_LENGTH 256
 
@@ -61,4 +63,6 @@ void free_i64_vector(int64_t *vector);
 void free_f32_vector(float *vector);
 } // extern "C"
 
+#ifdef __cplusplus
 #endif // WRAPPER_H
+#endif

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -32,7 +32,6 @@ template <typename T> static void readBinaryPOD(std::istream &in, T &podRef) {
   in.read((char *)&podRef, sizeof(T));
 }
 
-extern "C" {
 CError *new_error(int type_, const char *msg) {
   CError *err = (CError *)malloc(sizeof(CError));
   if (err == NULL) {
@@ -303,5 +302,3 @@ void free_f32_vector(float *vector) {
     delete[] vector;
   }
 }
-
-} // extern "C"

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -32,6 +32,8 @@ template <typename T> static void readBinaryPOD(std::istream &in, T &podRef) {
   in.read((char *)&podRef, sizeof(T));
 }
 
+extern "C" {
+
 CError *new_error(int type_, const char *msg) {
   CError *err = (CError *)malloc(sizeof(CError));
   if (err == NULL) {
@@ -302,3 +304,5 @@ void free_f32_vector(float *vector) {
     delete[] vector;
   }
 }
+
+} // extern "C"


### PR DESCRIPTION
From https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script
> the order of arguments passed to rustc may affect the order of arguments passed to the linker. Therefore, you will want to pay attention to the order of the build script’s instructions. For example, if object foo needs to link against library bar, you may want to make sure that library bar’s [cargo::rustc-link-lib](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-link-lib) instruction appears after instructions to link object foo.